### PR TITLE
Create symlink after installation

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,3 +27,20 @@
     state: "link"
     owner: "{{ nifi_user }}"
     group: "{{ nifi_group }}"
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: "directory"
+    owner: "{{ nifi_user }}"
+    group: "{{ nifi_group }}"
+  with_items:
+    - "{{ nifi_config_dirs.run }}"
+    - "{{ nifi_config_dirs.logs }}"
+
+- name: Set NiFi home
+  lineinfile:
+    path: "/etc/environment"
+    line: "export NIFI_HOME={{ nifi_config_dirs.home }}"
+    create: "yes"
+

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -22,11 +22,4 @@
     group: "{{ nifi_group }}"
   with_items:
     - "{{ nifi_config_dirs.install }}"
-    - "{{ nifi_config_dirs.run }}"
-    - "{{ nifi_config_dirs.logs }}"
-
-- name: Set NiFi home
-  lineinfile:
-    path: "/etc/environment"
-    line: "export NIFI_HOME={{ nifi_config_dirs.home }}"
-    create: "yes"
+ 

--- a/tasks/prepare.yml
+++ b/tasks/prepare.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install lxml python module
+  apt:
+    name: python3-lxml
+    state: present
+
 - name: Create NiFi group
   group:
     name: "{{ nifi_group }}"


### PR DESCRIPTION
Fix for errors:
```
TASK [ansible-nifi : Create NiFi symlink] *****************************************************************************
fatal: [0.0.0.0]: FAILED! => {"changed": false, "gid": 1001, "group": "nifi", "mode": "0755", "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /opt/nifi/releases/current/nifi-1.11.1", "owner":
 "nifi", "path": "/opt/nifi/releases/current", "size": 4096, "src": "nifi-1.11.1", "state": "directory", "uid": 1001}
```
Task wants to create symlink "current" after it was created as directory in the prepare task (where nifi isn't even unpacked yet)

Also installed missing lxml python package.