### PR TITLE
Fix zk default to prevent this start error

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,7 @@ zookeeper_myid: "{{ ansible_default_ipv4.address.split('.')[-1] }}"
 # Specify any property from zookeeper.properties here.
 zookeeper:
   dataDir: "{{ nifi_config_dirs.external_config }}/state/zookeeper"
+  clientPort: 2181
 
 # Specify ZooKeeper JAAS properties
 zookeeper_jaas: {}


### PR DESCRIPTION
If you don't set clientPort in zk defaults, you get this error and servers (zk/nifi) refuse to start. "No clientAddress or secureClientAddress is set in zookeeper.properties". By the way I just used your role for installing a 3 nodes Nifi 1.13.2 cluster, and with this fix, it seems ok. Thx